### PR TITLE
refactor: migrate app from HashRouter to BrowserRouter

### DIFF
--- a/packages/app/src/app/App.tsx
+++ b/packages/app/src/app/App.tsx
@@ -66,6 +66,7 @@ const App = () => {
             Mousetrap.unbind(["command+[", "ctrl+["]);
             Mousetrap.unbind(["command+]", "ctrl+]"]);
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(() => {

--- a/packages/app/src/app/App.tsx
+++ b/packages/app/src/app/App.tsx
@@ -45,8 +45,6 @@ const App = () => {
     const isLoadingPeople = PeopleStore.use(state => state.isLoading, shallowEqual);
     const { darkMode, hideScrollbars } = usePreferences(["darkMode", "hideScrollbars"]);
     const navigate = useNavigate();
-    const location = useLocation();
-    const locationState = location.state as { backgroundLocation?: Location };
 
     useUpdates();
 
@@ -90,18 +88,12 @@ const App = () => {
                         <Workspaces />
                         <SplitView
                             left={isLoadingPeople ? <Loading small /> : <Sidebar />}
-                            right={isLoadingPeople ? <Loading /> : <MainAppRoutes location={locationState?.backgroundLocation || location} />}
+                            right={isLoadingPeople ? <Loading /> : <RoutedMainAppRoutes />}
                         />
                     </div>
                 </div>
 
-                {locationState?.backgroundLocation && (
-                    <Routes>
-                        <Route path="/task/:id" element={<TaskDetailsPanel />} />
-                        <Route path="/person/:id" element={<PersonDetailsPanel />} />
-                        <Route path="/company/:id" element={<CompanyDetailsPanel />} />
-                    </Routes>
-                )}
+                <RoutedOverlayRoutes />
                 <AiChat />
             </DragDropProvider>
         </ErrorBoundary>
@@ -109,6 +101,29 @@ const App = () => {
 };
 
 export default App;
+
+const RoutedMainAppRoutesPure = () => {
+    const location = useLocation();
+    const locationState = location.state as { backgroundLocation?: Location };
+    return <MainAppRoutes location={locationState?.backgroundLocation || location} />;
+};
+const RoutedMainAppRoutes = React.memo(RoutedMainAppRoutesPure);
+
+const RoutedOverlayRoutesPure = () => {
+    const location = useLocation();
+    const locationState = location.state as { backgroundLocation?: Location };
+    if (!locationState?.backgroundLocation) {
+        return null;
+    }
+    return (
+        <Routes>
+            <Route path="/task/:id" element={<TaskDetailsPanel />} />
+            <Route path="/person/:id" element={<PersonDetailsPanel />} />
+            <Route path="/company/:id" element={<CompanyDetailsPanel />} />
+        </Routes>
+    );
+};
+const RoutedOverlayRoutes = React.memo(RoutedOverlayRoutesPure);
 
 interface MainAppRoutesProps {
     location: Location;

--- a/packages/app/src/app/components/project/QuickTimeLog/QuickTimeLog.tsx
+++ b/packages/app/src/app/components/project/QuickTimeLog/QuickTimeLog.tsx
@@ -16,10 +16,10 @@ import { DateInput } from "@blueprintjs/datetime";
 import { translate } from "@stacks/translations";
 import { ITimeLog } from "@stacks/types";
 import { addYears, format, parse } from "date-fns";
-import React, { FunctionComponent, useEffect, useMemo, useState } from "react";
+import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from "react";
 
 import { Col, Icon, Row } from "app/components/common";
-import { useMe } from "app/hooks";
+import { getHashPathname, useMe } from "app/hooks";
 import { TimelogsActions } from "app/store/actions";
 import { formatDuration } from "app/utils/date";
 import Toast from "app/utils/toast";
@@ -64,22 +64,22 @@ export const QuickTimeLog: FunctionComponent<IQuickTimeLogProps> = ({
         if (!person || (person !== me.id)) {
             setPerson(me.id);
         }
-    }, [me]);
+    }, [me, person]);
 
     useEffect(() => {
         if (projectId && projectId !== project) {
             setProject(projectId);
         }
-    }, [projectId])
+    }, [project, projectId, setProject])
 
     const canSave = useMemo(() => {
         return Boolean(duration) && Boolean(date) && Boolean(task) && Boolean(person) && Number(duration) > 0;
     }, [duration, date, task, person]);
 
-    const handleSetProject = (projectId: string) => {
+    const handleSetProject = useCallback((projectId: string) => {
         setProject(projectId);
         setTask(undefined);
-    };
+    }, [setProject]);
 
     const projectPicker = useMemo(() => {
         if (!changeProject) return null;
@@ -89,7 +89,7 @@ export const QuickTimeLog: FunctionComponent<IQuickTimeLogProps> = ({
                 <ProjectPickerPopup value={project} matchTargetWidth onChange={handleSetProject} />
             </FormGroup>
         );
-    }, [project, changeProject]);
+    }, [changeProject, project, handleSetProject]);
 
     const taskPicker = useMemo(() => {
         if (!changeTask || !project) return null;
@@ -304,7 +304,7 @@ export const QuickTimeLog: FunctionComponent<IQuickTimeLogProps> = ({
 };
 
 const useProject = (projectId?: string) => {
-    const slugs = window.location.hash.split("/");
+    const slugs = getHashPathname().split("/");
     const currentProject = slugs.at(1) === "project" ? slugs.at(2) : undefined;
     return useState<string | undefined>(projectId ?? currentProject);
 };

--- a/packages/app/src/app/components/project/Task/TaskDetails/TaskDetails.tsx
+++ b/packages/app/src/app/components/project/Task/TaskDetails/TaskDetails.tsx
@@ -133,11 +133,11 @@ export const TaskDetails = () => {
     }, [task]);
 
     const closeTask = () => {
-        if (window.location.hash.startsWith("#/mytasks")) {
+        if (getHashPathname().startsWith("/mytasks")) {
             navigate("/mytasks");
             return;
         }
-        if (window.location.hash.startsWith("#/tasks")) {
+        if (getHashPathname().startsWith("/tasks")) {
             const search = getHashSearch();
             navigate({ pathname: "/tasks", search: search || undefined });
             return;

--- a/packages/app/src/app/hooks/autocomplete.ts
+++ b/packages/app/src/app/hooks/autocomplete.ts
@@ -317,7 +317,7 @@ export const useAutocomplete = (options: {
                                 .map((person: IPerson) => {
                                     return {
                                         key: `${person.firstName} ${person.lastName}`,
-                                        value: `#/person/${person.id}`,
+                                        value: `/person/${person.id}`,
                                         icon: person.avatar ? undefined : APPICONS.PERSON,
                                         image: person.avatar,
                                         item: {

--- a/packages/app/src/app/hooks/project.ts
+++ b/packages/app/src/app/hooks/project.ts
@@ -191,7 +191,8 @@ const checkHasFilters = (filters: IFilters, defaultState: DefaultProjectState, c
     if (filters.priority != null) filterCount++;
 
     // check if we're inside the inbox or mytasks
-    const isProject = !window.location.hash.includes("inbox") && !window.location.hash.includes("mytasks");
+    const currentPath = getHashPathname();
+    const isProject = !currentPath.includes("inbox") && !currentPath.includes("mytasks");
 
     if (isProject && Boolean(defaultState)) {
         if (filters.state !== defaultState) filterCount++;

--- a/packages/app/src/app/hooks/router.ts
+++ b/packages/app/src/app/hooks/router.ts
@@ -7,16 +7,76 @@ import { useCallback, useEffect, useState } from "react";
 import { Location, NavigateOptions, useLocation } from "react-router-dom";
 import { publish } from "./event";
 
-/** Query string inside the hash (includes leading `?`), for HashRouter URLs like `#/project/1?f=1`. */
-export function getHashSearch(): string {
+export const APP_BASENAME = "/app";
+
+type WindowRouteSnapshot = {
+    pathname: string;
+    search: string;
+    hash: string;
+};
+
+function stripAppBasename(pathname: string): string {
+    if (!pathname || pathname === APP_BASENAME) {
+        return "/";
+    }
+
+    if (pathname.startsWith(`${APP_BASENAME}/`)) {
+        return pathname.slice(APP_BASENAME.length) || "/";
+    }
+
+    return pathname;
+}
+
+function getLegacyHashSnapshot(): WindowRouteSnapshot | null {
     const raw = window.location.hash.replace(/^#/, "");
-    const q = raw.indexOf("?");
-    return q === -1 ? "" : raw.slice(q);
+    if (!raw.startsWith("/")) {
+        return null;
+    }
+
+    const [pathname, search = ""] = raw.split("?");
+    return {
+        pathname: pathname || "/",
+        search: search ? `?${search}` : "",
+        hash: "",
+    };
+}
+
+function getCurrentWindowRouteSnapshot(): WindowRouteSnapshot {
+    const legacyHash = getLegacyHashSnapshot();
+    if (legacyHash) {
+        return legacyHash;
+    }
+
+    return {
+        pathname: stripAppBasename(window.location.pathname || "/") || "/",
+        search: window.location.search || "",
+        hash: window.location.hash || "",
+    };
+}
+
+/** Query string for the current app route (includes leading `?`). */
+export function getHashSearch(): string {
+    return getCurrentWindowRouteSnapshot().search;
+}
+
+/**
+ * Converts a legacy `#/route` URL into the BrowserRouter `/app/route` shape before React boots.
+ */
+export function normalizeLegacyHashRoute(): void {
+    const legacyHash = getLegacyHashSnapshot();
+    if (!legacyHash) {
+        return;
+    }
+
+    const nextUrl = `${APP_BASENAME}${legacyHash.pathname}${legacyHash.search}`;
+    const currentUrl = `${window.location.pathname}${window.location.search}`;
+    if (nextUrl !== currentUrl) {
+        window.history.replaceState(window.history.state, "", nextUrl);
+    }
 }
 
 /**
  * Background route for task modal overlay — reads the address bar synchronously (no `useLocation` subscription).
- * Supports HashRouter (`#/path?query`) and falls back to pathname/search on the rare non-hash URL.
  */
 export function snapshotTaskModalBackground(): {
     pathname: string;
@@ -24,20 +84,11 @@ export function snapshotTaskModalBackground(): {
     hash: string;
     state: null;
 } {
-    const rawHash = window.location.hash.replace(/^#/, "");
-    if (rawHash !== "") {
-        const pathname = getHashPathname() || "/";
-        return {
-            pathname,
-            search: getHashSearch(),
-            hash: "",
-            state: null,
-        };
-    }
+    const snapshot = getCurrentWindowRouteSnapshot();
     return {
-        pathname: window.location.pathname || "/",
-        search: window.location.search || "",
-        hash: window.location.hash || "",
+        pathname: snapshot.pathname,
+        search: snapshot.search,
+        hash: snapshot.hash,
         state: null,
     };
 }
@@ -79,14 +130,12 @@ export function getTaskModalListBackgroundFromHistory(): IBackgroundLocationStat
     return undefined;
 }
 
-/** Hash route path only (no `?query`) — needed before `matchPath` or `/`-split parsing. */
+/** Current app route path only (no `?query`) — kept under the old name for compatibility. */
 export function getHashPathname(): string {
-    const raw = window.location.hash.replace(/^#/, "");
-    const q = raw.indexOf("?");
-    return q === -1 ? raw : raw.slice(0, q);
+    return getCurrentWindowRouteSnapshot().pathname;
 }
 
-/** `/project/:projectId` or `/project/:projectId/:taskId` from the current hash. */
+/** `/project/:projectId` or `/project/:projectId/:taskId` from the current app URL. */
 export function getProjectIdFromHashPath(): string {
     const path = getHashPathname();
     const segments = path.split("/").filter(Boolean);

--- a/packages/app/src/app/store/actions/projects.ts
+++ b/packages/app/src/app/store/actions/projects.ts
@@ -10,7 +10,7 @@ import xor from "lodash/xor";
 import { DropResult } from "@hello-pangea/dnd";
 import { IAutomation, IField, IProject, IUpdate, PROJECTHEALTH } from "@stacks/types";
 import { ExportAPI, ProjectsAPI } from "app/api";
-import { getCurrentProjectId, nav, publish } from "app/hooks";
+import { getCurrentProjectId, getHashPathname, nav, publish } from "app/hooks";
 import { IProjectsStore, ProjectsStore } from "app/store/projects";
 import Dialog from "app/utils/dialog";
 import { getStorage, setStorage } from "app/utils/storage";
@@ -293,7 +293,7 @@ const removeById = async (projectId: string) => {
         })
     );
 
-    if (window.location.hash.includes(projectId)) {
+    if (getHashPathname().includes(projectId)) {
         nav("/");
     }
 };

--- a/packages/app/src/app/store/actions/recents.ts
+++ b/packages/app/src/app/store/actions/recents.ts
@@ -7,7 +7,7 @@ import { produce } from "immer";
 import { IRecentsStore, RecentsStore } from "../recents";
 import { getStorage, setStorage } from "app/utils/storage";
 import { IRecentItem } from "@stacks/types";
-import { nav } from "app/hooks";
+import { getHashPathname, nav } from "app/hooks";
 import { stripMd } from "app/utils/string";
 
 const load = () => {
@@ -90,7 +90,7 @@ const goToLastItem = () => {
 
     if (lastItem) {
         // check if the current URL match the last viewed item
-        if (window.location.hash.replace("#", "") !== lastItem.url) {
+        if (getHashPathname() !== lastItem.url) {
             nav(lastItem.url);
         }
     }

--- a/packages/app/src/app/store/actions/tasks.ts
+++ b/packages/app/src/app/store/actions/tasks.ts
@@ -40,6 +40,7 @@ import {
 import api, { PermissionsAPI, TaskLoadParams, TasksAPI } from "app/api";
 import {
     getCurrentProjectId,
+    getHashPathname,
     getCurrentTaskId,
     getMe,
     getStack,
@@ -1059,7 +1060,7 @@ const archive = async (taskId: string) => {
     // skip archivation if the task is a subtask
     if (task.parent != undefined) return;
 
-    if (window.location.hash.includes(taskId)) {
+    if (getHashPathname().includes(taskId)) {
         nav(`/project/${task.project}`);
     }
 

--- a/packages/app/src/app/widgets/aiChat/AiChat.tsx
+++ b/packages/app/src/app/widgets/aiChat/AiChat.tsx
@@ -4,11 +4,11 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { Icon } from "app/components/common";
+import { getHashPathname, getProjectLastView, getViewType } from "app/hooks";
 import { shallowEqual } from "app/hooks/store";
 import { AiChatActions } from "app/store/actions/aiChat";
 import { AiChatStore, type AiChatMessage } from "app/store/aiChat";
 import toast from "app/utils/toast";
-import { getProjectLastView, getViewType } from "app/hooks";
 
 import { AiChatMarkdown } from "./AiChatMarkdown";
 
@@ -150,10 +150,10 @@ export const AiChat: React.FC = () => {
         const nextMessages = [...history, { role: "user" as const, content: text }];
 
         try {
-            const route = window.location.hash.replace("#/", "").split("/");
+            const route = getHashPathname().split("/").filter(Boolean);
             const clientRoute: Record<string, string> = {
-                section: route[0],
-                sectionId: route[1],
+                section: route[0] ?? "",
+                sectionId: route[1] ?? "",
             };
 
             if (clientRoute.section === "project") {

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -3,11 +3,12 @@ import { Position, OverlayToaster, Spinner } from "@blueprintjs/core";
 import "app/utils/prototypes";
 import React, { Suspense } from "react";
 import { createRoot } from "react-dom/client";
-import { HashRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 
 import "./index.scss";
 import { setTranslations } from "@stacks/translations";
 import { UpdatePoller } from "app/utils/polling";
+import { APP_BASENAME, normalizeLegacyHashRoute } from "app/hooks/router";
 import { PreferencesActions } from "app/store/actions/preferences";
 import { BootAPI } from "app/api";
 import { AiChatActions } from "app/store/actions/aiChat";
@@ -31,6 +32,7 @@ const initToast = async () => {
 };
 
 initToast();
+normalizeLegacyHashRoute();
 
 window.updatePoller = new UpdatePoller();
 window.addEventListener("beforeunload", () => {
@@ -56,9 +58,9 @@ void (async () => {
 
     root.render(
         <Suspense fallback={<AppLoading />}>
-            <HashRouter>
+            <BrowserRouter basename={APP_BASENAME}>
                 <App />
-            </HashRouter>
+            </BrowserRouter>
         </Suspense>
     );
 })();

--- a/packages/app/webpack.config.cjs
+++ b/packages/app/webpack.config.cjs
@@ -88,7 +88,7 @@ module.exports = (env, argv) => {
     process.env.NODE_ENV = mode;
     process.env.BABEL_ENV = process.env.BABEL_ENV || mode;
     const isProd = mode === "production";
-    const publicUrl = (process.env.PUBLIC_URL || "").replace(/\/$/, "");
+    const publicUrl = (process.env.PUBLIC_URL || "/app").replace(/\/$/, "");
 
     const htmlTemplate = fs
         .readFileSync(path.join(publicDir, "index.html"), "utf8")
@@ -106,7 +106,7 @@ module.exports = (env, argv) => {
             filename: isProd ? "static/js/[name].[contenthash:8].js" : "static/js/bundle.js",
             chunkFilename: isProd ? "static/js/[name].[contenthash:8].chunk.js" : "static/js/[name].chunk.js",
             assetModuleFilename: "static/media/[name].[hash][ext]",
-            publicPath: isProd ? "./" : "/",
+            publicPath: `${publicUrl}/`,
             clean: isProd,
         },
         resolve: {
@@ -377,8 +377,8 @@ module.exports = (env, argv) => {
         devServer: !isProd
             ? {
                   hot: true,
-                  historyApiFallback: { disableDotRule: true },
-                  static: { directory: publicDir, publicPath: "/" },
+                  historyApiFallback: { disableDotRule: true, index: `${publicUrl}/` },
+                  static: { directory: publicDir, publicPath: `${publicUrl}/` },
                   compress: true,
                   port: process.env.PORT ? Number(process.env.PORT) : 3001,
                   host: process.env.HOST || "0.0.0.0",

--- a/packages/server/src/ai/chat.ts
+++ b/packages/server/src/ai/chat.ts
@@ -16,7 +16,7 @@ import { buildAiTools } from "./tools";
 
 export type AiChatClientMessage = { role: "user" | "assistant"; content: string };
 
-/** Client: `button` shows a click target; `redirect` navigates to `hashPath` without a click. */
+/** Client: `button` shows a click target; `redirect` navigates to the app path without a click. */
 export type AiChatWidget =
     | { type: "button"; label: string; hashPath: string }
     | { type: "redirect"; label: string; hashPath: string };
@@ -118,7 +118,7 @@ function currentUserTemplateVars(): {
  * they show a button the user can click.
  *
  * Do NOT use this for side-effect tools (`createTask`, `findTasks`, etc.) —
- * those return a `hashPath` as a courtesy link, not as a "take me there"
+ * those return a route path as a courtesy link, not as a "take me there"
  * instruction. Use `aiChatLinkWidget` for those to prevent a very unpleasant
  * "every answer teleports me to /tasks" UX.
  */
@@ -156,11 +156,11 @@ function widgetsFromToolResult(toolName: string, output: unknown): AiChatWidget[
         if (typeof id !== "string" || typeof projectId !== "string") {
             return [];
         }
-        return [aiChatLinkWidget(`Open: ${title}`, `#/project/${projectId}/${id}`)];
+        return [aiChatLinkWidget(`Open: ${title}`, `/project/${projectId}/${id}`)];
     }
 
     if (toolName === "createProject" && typeof id === "string") {
-        return [aiChatLinkWidget(`Open project: ${title}`, `#/project/${id}`)];
+        return [aiChatLinkWidget(`Open project: ${title}`, `/project/${id}`)];
     }
 
     if (toolName === "findTasks" && typeof o.hashPath === "string") {

--- a/packages/server/src/ai/clientRoute.ts
+++ b/packages/server/src/ai/clientRoute.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2026 Cristian Barlutiu — Licensed under AGPL v3. See LICENSE.
 /**
- * Route shape sent from the React app (HashRouter location).
+ * Route shape sent from the React app.
  */
 export type AiChatClientRoutePayload = {
     section: string;

--- a/packages/server/src/ai/toolRegistry/navigationTools.ts
+++ b/packages/server/src/ai/toolRegistry/navigationTools.ts
@@ -1,6 +1,6 @@
 // Copyright (C) 2026 Cristian Barlutiu — Licensed under AGPL v3. See LICENSE.
 /**
- * AI tools: UI navigation. Produces a `hashPath` plus a `label` that the client bridge
+ * AI tools: UI navigation. Produces an app path plus a `label` that the client bridge
  * turns into an auto-redirect or a click-to-open button (see `aiChatNavigationWidget`).
  *
  * Keep routes in sync with `packages/app/src/app/App.tsx` `MainAppRoutes`.
@@ -35,37 +35,37 @@ const VIEW_LABELS: Record<string, string> = {
 function buildHashPath(view: string, id: string | undefined): string {
     switch (view) {
         case "home":
-            return "#/home";
+            return "/home";
         case "calendar":
-            return "#/calendar";
+            return "/calendar";
         case "inbox":
-            return "#/inbox";
+            return "/inbox";
         case "myTasks":
-            return "#/mytasks";
+            return "/mytasks";
         case "bookmarks":
-            return "#/bookmarks";
+            return "/bookmarks";
         case "reports":
-            return "#/reports";
+            return "/reports";
         case "people":
-            return "#/people";
+            return "/people";
         case "myProfile":
-            return `#/person/${getCurrentUser().id}`;
+            return `/person/${getCurrentUser().id}`;
         case "project":
-            return `#/project/${id}`;
+            return `/project/${id}`;
         case "person":
-            return `#/person/${id}`;
+            return `/person/${id}`;
         case "company":
-            return `#/company/${id}`;
+            return `/company/${id}`;
         case "notepad":
-            return `#/notepad/${id}`;
+            return `/notepad/${id}`;
         case "goal":
-            return `#/goal/${id}`;
+            return `/goal/${id}`;
         case "file":
-            return `#/file/${id}`;
+            return `/file/${id}`;
         case "task":
-            return `#/task/${id}`;
+            return `/task/${id}`;
         case "reportType":
-            return `#/reports/${id}`;
+            return `/reports/${id}`;
         default:
             throw new Error(`Unsupported view: ${view}`);
     }

--- a/packages/server/src/ai/toolRegistry/peopleTools.ts
+++ b/packages/server/src/ai/toolRegistry/peopleTools.ts
@@ -111,7 +111,7 @@ export const peopleAiTools = [
 
     defineTool({
         name: "openProfile",
-        description: `Open a person's profile page in the app. Omit personId to open the current user's own profile ("my profile"). Returns a hashPath the UI can navigate to.`,
+        description: `Open a person's profile page in the app. Omit personId to open the current user's own profile ("my profile"). Returns a path the UI can navigate to.`,
         inputSchema: z.object({
             personId: z
                 .string()
@@ -124,7 +124,7 @@ export const peopleAiTools = [
             return {
                 personId: id,
                 isSelf,
-                hashPath: `#/person/${id}`,
+                hashPath: `/person/${id}`,
                 label: isSelf ? "Open my profile" : "Open profile",
             };
         },

--- a/packages/server/src/ai/toolRegistry/taskTools.ts
+++ b/packages/server/src/ai/toolRegistry/taskTools.ts
@@ -201,7 +201,7 @@ function findTasksInputToQueryString(input: {
 export const taskAiTools = [
     defineTool({
         name: "findTasks",
-        description: `Find / search / show / open tasks in the app UI. Returns hashPath (#/tasks?...) to navigate. Use listProjects first if you need a projectId. For listing tasks inside the chat instead, use listTasks. "assigned to me / <person>" → assigneeUserIds (NOT assignedOnly).`,
+        description: `Find / search / show / open tasks in the app UI. Returns hashPath (/tasks?...) to navigate. Use listProjects first if you need a projectId. For listing tasks inside the chat instead, use listTasks. "assigned to me / <person>" → assigneeUserIds (NOT assignedOnly).`,
         inputSchema: z
             .object({
                 projectId: z.string().uuid().optional().describe("Single project UUID"),
@@ -246,7 +246,7 @@ export const taskAiTools = [
             const queryString = findTasksInputToQueryString(input);
             return {
                 queryString,
-                hashPath: queryString.length > 0 ? `#/tasks?${queryString}` : "#/tasks",
+                hashPath: queryString.length > 0 ? `/tasks?${queryString}` : "/tasks",
             };
         },
     }),

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -2,7 +2,8 @@
 /**
  * Mounts versioned JSON API, static assets, and authenticated route modules on a Hono app.
  */
-import { Hono } from "hono";
+import { extname } from "node:path";
+import { Context, Hono } from "hono";
 import { proxy } from "hono/proxy";
 import { serveStatic } from "@hono/node-server/serve-static";
 
@@ -35,6 +36,24 @@ import roles from "./routes/roles";
 import exportRoute from "./routes/export";
 import info from "./routes/info";
 
+const APP_STATIC_ROOT = "./app";
+
+function getAppProxyHeaders(c: Context) {
+    return {
+        ...c.req.header(),
+        cookie: c.req.header("cookie") || "",
+    };
+}
+
+function rewriteAppRequestPath(path: string): string {
+    return path.replace(/^\/app/, "") || "/";
+}
+
+function isAppAssetRequest(path: string): boolean {
+    const relativePath = rewriteAppRequestPath(path);
+    return relativePath.startsWith("/static/") || extname(relativePath) !== "";
+}
+
 /**
  * Register API routes with conditional static file serving
  *
@@ -51,16 +70,23 @@ export const registerApiRoutes = (app: Hono) => {
 
     if (isDevelopment) {
         // Development: Proxy to React dev server
+        app.all("/app", requireAuthSession, c => {
+            const user = c.get("user") as User;
+            if (!user) {
+                return c.redirect("/login");
+            }
+            return proxy(`http://localhost:3001/app/`, {
+                headers: getAppProxyHeaders(c),
+            });
+        });
+
         app.all("/app/*", requireAuthSession, c => {
             const user = c.get("user") as User;
             if (!user) {
                 return c.redirect("/login");
             }
             return proxy(`http://localhost:3001${c.req.path}`, {
-                headers: {
-                    ...c.req.header(),
-                    cookie: c.req.header("cookie") || "",
-                },
+                headers: getAppProxyHeaders(c),
             });
         });
 
@@ -80,19 +106,27 @@ export const registerApiRoutes = (app: Hono) => {
         // Serve other static files by extension (CSS, JS, images, etc.)
         app.use("*", async (c, next) => {
             return serveStatic({
-                root: "./app",
+                root: APP_STATIC_ROOT,
             })(c, next);
         });
 
-        // Serve app files automatically from static folder
-        app.use(
-            "/app/*",
-            requireAuthSession,
-            serveStatic({
-                root: "./app",
-                rewriteRequestPath: (path: string) => path.replace(/^\/app/, ""),
-            })
-        );
+        const serveAppIndex = serveStatic({
+            root: APP_STATIC_ROOT,
+            rewriteRequestPath: () => "/index.html",
+        });
+
+        const serveAppAsset = serveStatic({
+            root: APP_STATIC_ROOT,
+            rewriteRequestPath: rewriteAppRequestPath,
+        });
+
+        app.use("/app", requireAuthSession, serveAppIndex);
+        app.use("/app/*", requireAuthSession, async (c, next) => {
+            if (isAppAssetRequest(c.req.path)) {
+                return serveAppAsset(c, next);
+            }
+            return serveAppIndex(c, next);
+        });
     }
 
     // Google OAuth routes (no auth required for some endpoints)

--- a/playwright/tests/project/board-column.spec.ts
+++ b/playwright/tests/project/board-column.spec.ts
@@ -36,7 +36,7 @@ test.describe("Project - Board column", () => {
         const matchingProjects = sidebar.documentsTreeItems.filter({ hasText: projectName });
         const count = await matchingProjects.count();
         expect(count).toBeGreaterThanOrEqual(1);
-        await expect(page).toHaveURL(`/app#/project/${projectId}?state=todo`);
+        await expect(page).toHaveURL(`/app/project/${projectId}?state=todo`);
 
         await board.addColumn(MAIN_COLUMN);
     });

--- a/playwright/tests/project/board-view.spec.ts
+++ b/playwright/tests/project/board-view.spec.ts
@@ -60,7 +60,7 @@ test.describe("Project - Board view", () => {
             const matchingProjects = sidebar.documentsTreeItems.filter({ hasText: projectName });
             const count = await matchingProjects.count();
             expect(count).toBeGreaterThanOrEqual(1);
-            await expect(page).toHaveURL(`/app#/project/${projectId}`);
+            await expect(page).toHaveURL(`/app/project/${projectId}`);
         });
 
         await test.step("Should add the first column via the blank slate", async () => {

--- a/playwright/tests/project/list-view.spec.ts
+++ b/playwright/tests/project/list-view.spec.ts
@@ -24,7 +24,7 @@ test.describe("Project - List view", () => {
         const projectId = await project.addNew({ name: TEST_PROJECT });
         const matchingProjects = sidebar.documentsTreeItems.filter({ hasText: TEST_PROJECT });
         await expect(matchingProjects).toHaveCount(1);
-        await expect(page).toHaveURL(`/app#/project/${projectId}`);
+        await expect(page).toHaveURL(`/app/project/${projectId}`);
     });
 
     test.beforeEach(({ attachVideoContext }: any) => {

--- a/playwright/tests/project/task-details.spec.ts
+++ b/playwright/tests/project/task-details.spec.ts
@@ -41,7 +41,7 @@ test.describe("Project - Task details", () => {
         const matchingProjects = sidebar.documentsTreeItems.filter({ hasText: projectName });
         const count = await matchingProjects.count();
         expect(count).toBeGreaterThanOrEqual(1);
-        await expect(page).toHaveURL(`/app#/project/${projectId}`);
+        await expect(page).toHaveURL(`/app/project/${projectId}`);
 
         await board.addColumn(MAIN_COLUMN);
         await project.addTask({


### PR DESCRIPTION
## Summary

This commit fully migrates the application from HashRouter to BrowserRouter:
- Replace HashRouter with BrowserRouter in the app entrypoint, set basename to /app
- Add legacy hash route normalization to support existing URLs during migration
- Replace all direct window.location.hash checks with the new getHashPathname utility
- Update all hardcoded #/... paths to use proper relative /... paths
- Rewrite server static serving and dev proxy config to support SPA routing under /app
- Fix useEffect dependency warnings in App and QuickTimeLog components
- Update AI tool definitions and comments to match the new routing system

## Changes

-

## How To Test

1. While browsing the app the hashtag `#` should not be visible in the URL

## Screenshots / Recordings (if UI changes)

### Before

### After

## Checklist

-   [x] This PR targets `dev` (not `main`)
-   [x] I ran the relevant tests locally
-   [x] I added/updated tests where appropriate
-   [x] I updated documentation where appropriate
-   [x] I verified this change does not introduce a security/privacy concern
-   [x] I considered backwards compatibility and migrations (if applicable)
-   [x] I signed the CLA (required for first-time contributors)

## CLA (first-time contributors)

I have read the Contributor License Agreement in `.github/CLA.md` and I hereby agree to its terms. My GitHub username is @synapse .

