### PR TITLE
feat(calendar): add recurring Google event deletion

### DIFF
--- a/packages/app/src/app/api/events.ts
+++ b/packages/app/src/app/api/events.ts
@@ -16,6 +16,13 @@ interface LoadTasksParams {
     projects: string[];
 }
 
+export interface EventDeleteParams {
+    scope?: "single" | "series";
+    calendarId?: string;
+    googleEventId?: string;
+    recurringEventId?: string;
+}
+
 export const EventsAPI = {
     /** Lists events for a calendar view and anchor date. */
     async loadEvents(from: Date, to: Date, calendars?: string[]): Promise<ICalendarEvent[]> {
@@ -36,8 +43,10 @@ export const EventsAPI = {
         return request.patch(`/api/events/${eventId}`, event);
     },
     /** Deletes an event. */
-    async remove(eventId: string): Promise<boolean> {
-        return request.delete(`/api/events/${eventId}`);
+    async remove(eventId: string, params?: EventDeleteParams): Promise<boolean> {
+        return request.delete(`/api/events/${eventId}`, {
+            params,
+        });
     },
     /** Event count for today. */
     async getTodaysEvents(): Promise<number> {

--- a/packages/app/src/app/store/actions/calendar.ts
+++ b/packages/app/src/app/store/actions/calendar.ts
@@ -2,7 +2,7 @@
 /**
  * Calendar data loading and mutations.
  */
-import api, { CalendarIntegrationsAPI, type CalendarProvider, EventsAPI } from "app/api";
+import api, { CalendarIntegrationsAPI, type CalendarProvider, type EventDeleteParams, EventsAPI } from "app/api";
 import {
     addDays,
     addHours,
@@ -26,6 +26,10 @@ import { getDatesSpan } from "app/hooks";
 import Dialog from "app/utils/dialog";
 import Toast from "app/utils/toast";
 import Storage from "app/utils/storage";
+import {
+    showRecurringDeleteDialog,
+    type RecurringDeleteScope,
+} from "app/widgets/calendar/RecurringDeleteDialog/RecurringDeleteDialog";
 import { patchFilterField } from "../actionHelpers";
 import { CALENDAR_FILTERS_STORAGE_KEY, CalendarStore, ICalendarFilters, ICalendarStore } from "../calendar";
 import { TasksActions } from "./tasks";
@@ -37,6 +41,31 @@ const savePrefs = async () => {
 
 const persistFilters = () => {
     Storage.set(CALENDAR_FILTERS_STORAGE_KEY, CalendarStore.get().filters);
+};
+
+const findCalendarEvent = (eventId: string): ICalendarEvent | undefined => {
+    const event = CalendarStore.get().events.find(item => item.resource.data.id === eventId);
+    if (!event || event.resource.type !== EVENTTYPE.EVENT) return undefined;
+    return event.resource.data as ICalendarEvent;
+};
+
+const isRecurringGoogleEvent = (event?: ICalendarEvent): boolean => {
+    return event?.source === "google" && event.original?.google?.isRecurringInstance === true;
+};
+
+const buildDeleteParams = (
+    event?: ICalendarEvent,
+    scope: RecurringDeleteScope = "single"
+): EventDeleteParams | undefined => {
+    const google = event?.original?.google;
+    if (event?.source !== "google" || !google) return undefined;
+
+    return {
+        scope,
+        calendarId: google.calendarId,
+        googleEventId: google.eventId,
+        recurringEventId: google.recurringEventId,
+    };
 };
 
 let loadingCalendar = false;
@@ -535,10 +564,24 @@ const addTempEvent = async (startDate: Date, endDate: Date) => {
     }
 };
 
-const deleteEvent = async (eventId: string) => {
-    const deleted: boolean = await EventsAPI.remove(eventId);
+const deleteEvent = async (eventOrId: string | ICalendarEvent, scope: RecurringDeleteScope = "single") => {
+    const event = typeof eventOrId === "string" ? findCalendarEvent(eventOrId) : eventOrId;
+    const eventId = typeof eventOrId === "string" ? eventOrId : eventOrId.id;
+    const deleted: boolean = await EventsAPI.remove(eventId, buildDeleteParams(event, scope));
 
     if (deleted) {
+        if (event?.source === "google") {
+            CalendarStore.set(
+                produce((state: ICalendarStore) => {
+                    if (state.selected && state.selected[0] === eventId) {
+                        state.selected = undefined;
+                    }
+                })
+            );
+            await reload();
+            return;
+        }
+
         CalendarStore.set(
             produce((state: ICalendarStore) => {
                 state.events = state.events.filter(ev => ev.resource.data.id !== eventId);
@@ -552,14 +595,24 @@ const deleteEvent = async (eventId: string) => {
     }
 };
 
-const deleteEventAlert = async (eventId: string) => {
+const deleteEventAlert = async (eventOrId: string | ICalendarEvent) => {
+    const event = typeof eventOrId === "string" ? findCalendarEvent(eventOrId) : eventOrId;
+
+    if (event && isRecurringGoogleEvent(event)) {
+        const scope = await showRecurringDeleteDialog();
+        if (!scope) return false;
+
+        await deleteEvent(event, scope);
+        return true;
+    }
+
     const response = await Dialog.confirm(
         "Delete event",
         "Are you sure you want to remove this event? This action cannot be undone!"
     );
 
     if (response) {
-        await deleteEvent(eventId);
+        await deleteEvent(event ?? eventOrId);
     }
 
     return response;
@@ -569,14 +622,9 @@ const deleteSelectedEvent = async () => {
     const selectedEventId = CalendarStore.get().selected;
     if (selectedEventId == null) return;
 
-    const selectedEvent = CalendarStore.get().events.find(
-        event => event.resource.data.id === selectedEventId[0]
-    );
-
-
-
-    if (selectedEvent && selectedEvent.resource.type === EVENTTYPE.EVENT) {
-        await deleteEventAlert(selectedEventId[0]);
+    const selectedEvent = findCalendarEvent(selectedEventId[0]);
+    if (selectedEvent) {
+        await deleteEventAlert(selectedEvent);
     }
 };
 
@@ -714,7 +762,7 @@ const moveEvent = async (event: ICalendarEvent, calendar: string, source: ICalen
             return;
         }
 
-        await deleteEvent(event.id);
+        await deleteEvent(event);
         selectEvent(savedEvent.id, EVENTTYPE.EVENT);
         await reload();
     } catch (error) {

--- a/packages/app/src/app/widgets/calendar/RecurringDeleteDialog/RecurringDeleteDialog.tsx
+++ b/packages/app/src/app/widgets/calendar/RecurringDeleteDialog/RecurringDeleteDialog.tsx
@@ -1,0 +1,77 @@
+// Copyright (C) 2026 Cristian Barlutiu — Licensed under AGPL v3. See LICENSE.
+import { Button, Classes, Dialog, Intent } from "@blueprintjs/core";
+import React, { FunctionComponent, useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+
+export type RecurringDeleteScope = "single" | "series";
+
+interface RecurringDeleteDialogProps {
+    onClose: (scope: RecurringDeleteScope | null) => void;
+}
+
+export const RecurringDeleteDialog: FunctionComponent<RecurringDeleteDialogProps> = ({ onClose }) => {
+    const [isOpen, setIsOpen] = useState(true);
+    const result = useRef<RecurringDeleteScope | null>(null);
+
+    const handleClose = (scope: RecurringDeleteScope | null) => {
+        result.current = scope;
+        setIsOpen(false);
+    };
+
+    return (
+        <Dialog
+            isOpen={isOpen}
+            canEscapeKeyClose
+            canOutsideClickClose
+            title="Delete recurring event"
+            onClose={() => handleClose(null)}
+            onClosed={() => onClose(result.current)}
+        >
+            <div className={Classes.DIALOG_BODY}>
+                <p>This event is part of a series. What would you like to delete?</p>
+            </div>
+            <div className={Classes.DIALOG_FOOTER}>
+                <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+                    <Button
+                        data-testid="recurring-delete-cancel"
+                        variant="minimal"
+                        onClick={() => handleClose(null)}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        data-testid="recurring-delete-single"
+                        intent={Intent.DANGER}
+                        onClick={() => handleClose("single")}
+                    >
+                        Only this event
+                    </Button>
+                    <Button
+                        data-testid="recurring-delete-series"
+                        intent={Intent.DANGER}
+                        onClick={() => handleClose("series")}
+                    >
+                        Entire series
+                    </Button>
+                </div>
+            </div>
+        </Dialog>
+    );
+};
+
+export const showRecurringDeleteDialog = (): Promise<RecurringDeleteScope | null> => {
+    return new Promise(resolve => {
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+
+        const root = createRoot(container);
+
+        const handleResolve = (scope: RecurringDeleteScope | null) => {
+            resolve(scope);
+            root.unmount();
+            document.body.removeChild(container);
+        };
+
+        root.render(<RecurringDeleteDialog onClose={handleResolve} />);
+    });
+};

--- a/packages/app/src/app/widgets/calendar/RecurringDeleteDialog/__tests__/RecurringDeleteDialog.spec.tsx
+++ b/packages/app/src/app/widgets/calendar/RecurringDeleteDialog/__tests__/RecurringDeleteDialog.spec.tsx
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 Cristian Barlutiu — Licensed under AGPL v3. See LICENSE.
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { RecurringDeleteDialog } from "../RecurringDeleteDialog";
+
+jest.mock("@blueprintjs/core", () => {
+    // Use React from the module scope since imports can't be inside the jest mock factory function
+
+    return {
+        Button: ({ children, onClick, ...props }: any) => (
+            <button type="button" onClick={onClick} {...props}>
+                {children}
+            </button>
+        ),
+        Dialog: ({ isOpen, onClosed, title, children }: any) => {
+            React.useEffect(() => {
+                if (!isOpen) {
+                    onClosed?.();
+                }
+            }, [isOpen, onClosed]);
+
+            if (!isOpen) return null;
+
+            return (
+                <div>
+                    <div>{title}</div>
+                    {children}
+                </div>
+            );
+        },
+        Classes: {
+            DIALOG_BODY: "dialog-body",
+            DIALOG_FOOTER: "dialog-footer",
+            DIALOG_FOOTER_ACTIONS: "dialog-footer-actions",
+        },
+        Intent: {
+            DANGER: "danger",
+        },
+    };
+});
+
+describe("RecurringDeleteDialog", () => {
+    it("returns single when the single occurrence option is selected", async () => {
+        const onClose = jest.fn();
+
+        render(<RecurringDeleteDialog onClose={onClose} />);
+
+        fireEvent.click(screen.getByText("Only this event"));
+
+        await waitFor(() => {
+            expect(onClose).toHaveBeenCalledWith("single");
+        });
+    });
+
+    it("returns series when the entire series option is selected", async () => {
+        const onClose = jest.fn();
+
+        render(<RecurringDeleteDialog onClose={onClose} />);
+
+        fireEvent.click(screen.getByText("Entire series"));
+
+        await waitFor(() => {
+            expect(onClose).toHaveBeenCalledWith("series");
+        });
+    });
+});

--- a/packages/server/src/loaders/events.ts
+++ b/packages/server/src/loaders/events.ts
@@ -22,6 +22,13 @@ interface EventsFilter {
     calendars?: string[];
 }
 
+interface EventDeleteOptions {
+    scope?: "single" | "series";
+    calendarId?: string;
+    googleEventId?: string;
+    recurringEventId?: string;
+}
+
 interface Where {
     start?: {
         [Op.gte]: Date;
@@ -46,6 +53,27 @@ function normalizeIsoDateTime(value: unknown): string | undefined {
     if (typeof value === "string") return value;
     if (value instanceof Date) return value.toISOString();
     return undefined;
+}
+
+function resolveGoogleDeleteTarget(
+    id: string,
+    options?: EventDeleteOptions
+): { calendarId: string; googleEventId: string } | null {
+    const scopedEventId =
+        options?.scope === "series" ? options.recurringEventId ?? options.googleEventId : options?.googleEventId;
+
+    if (options?.calendarId && scopedEventId) {
+        return {
+            calendarId: options.calendarId,
+            googleEventId: scopedEventId,
+        };
+    }
+
+    if (options?.scope === "series") {
+        return null;
+    }
+
+    return parseGoogleCompositeEventId(id);
 }
 
 /**
@@ -78,6 +106,13 @@ function convertGoogleEventsToLocalFormat(googleEvents: GoogleCalendarEvent[], c
             location: googleEvent.location || "",
             original: {
                 htmlLink: googleEvent.htmlLink,
+                google: {
+                    calendarId,
+                    eventId: googleEvent.id,
+                    recurringEventId: googleEvent.recurringEventId,
+                    originalStartTime: googleEvent.originalStartTime,
+                    isRecurringInstance: googleEvent.recurringEventId != null,
+                },
             },
             // externalId: googleEvent.id,
             // htmlLink: googleEvent.htmlLink,
@@ -380,17 +415,31 @@ async function update(id: string, data: Partial<ICalendarEvent>) {
     }
 }
 
-async function remove(id: string) {
+async function remove(id: string, options?: EventDeleteOptions) {
     try {
         const user = getCurrentUser();
         if (id.startsWith("google_")) {
-            const parsed = parseGoogleCompositeEventId(id);
+            const parsed = resolveGoogleDeleteTarget(id, options);
             if (!parsed) {
                 throw Errors.invalidInput("Invalid Google event id");
             }
 
             try {
-                await googleOAuthService.deleteCalendarEvent(user.id, parsed.calendarId, parsed.googleEventId);
+                const shouldCancelRecurringInstance =
+                    options?.scope === "single" &&
+                    options.recurringEventId != null &&
+                    options.googleEventId != null &&
+                    options.googleEventId === parsed.googleEventId;
+
+                if (shouldCancelRecurringInstance) {
+                    await googleOAuthService.cancelCalendarEventInstance(
+                        user.id,
+                        parsed.calendarId,
+                        parsed.googleEventId
+                    );
+                } else {
+                    await googleOAuthService.deleteCalendarEvent(user.id, parsed.calendarId, parsed.googleEventId);
+                }
                 return true;
             } catch (error: any) {
                 const status = error?.response?.status ?? error?.code;

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -7,7 +7,13 @@ import type { Context } from "hono";
 import { translate } from "@stacks/translations";
 
 import { EventsLoader } from "../loaders";
-import { EventSchema, EventsCountSchema, EventsFilteredSchema, EventUpdateSchema } from "./schema/event";
+import {
+    EventDeleteSchema,
+    EventSchema,
+    EventsCountSchema,
+    EventsFilteredSchema,
+    EventUpdateSchema,
+} from "./schema/event";
 import { validator } from "../middleware/validator";
 import { cacheMiddleware } from "../utils/cache";
 import { Errors } from "../errors";
@@ -69,10 +75,12 @@ events.patch(
 /** DELETE `/:id` — Deletes an event; 404 if missing. */
 events.delete(
     "/:id",
+    validator(EventDeleteSchema, "query"),
     asyncHandler(async (c: Context) => {
         const eventId = c.req.param("id");
+        const deleteOptions = c.req.valid("query");
 
-        const deleted = await EventsLoader.remove(eventId!);
+        const deleted = await EventsLoader.remove(eventId!, deleteOptions);
         if (!deleted) {
             throw Errors.notFound(translate("Event not found"));
         }

--- a/packages/server/src/routes/schema/event.ts
+++ b/packages/server/src/routes/schema/event.ts
@@ -99,3 +99,49 @@ export const EventsCountSchema = z
         to: z.iso.datetime().optional(),
     })
     .strict();
+
+export const EventDeleteSchema = z
+    .object({
+        scope: z.enum(["single", "series"]).optional(),
+        calendarId: z.string().optional(),
+        googleEventId: z.string().optional(),
+        recurringEventId: z.string().optional(),
+    })
+    .strict()
+    .check(payload => {
+        const value = payload.value;
+        const hasGoogleCalendar = value.calendarId != null;
+        const hasGoogleEvent = value.googleEventId != null;
+        const hasRecurringEvent = value.recurringEventId != null;
+
+        if (!hasGoogleCalendar && !hasGoogleEvent && !hasRecurringEvent) {
+            return;
+        }
+
+        if (!hasGoogleCalendar) {
+            payload.issues.push({
+                code: "custom",
+                message: "calendarId is required for Google deletes",
+                path: ["calendarId"],
+                input: value,
+            });
+        }
+
+        if (!hasGoogleEvent && !hasRecurringEvent) {
+            payload.issues.push({
+                code: "custom",
+                message: "A Google event identifier is required",
+                path: ["googleEventId"],
+                input: value,
+            });
+        }
+
+        if (value.scope === "series" && !hasRecurringEvent && !hasGoogleEvent) {
+            payload.issues.push({
+                code: "custom",
+                message: "A recurring event identifier is required to delete a series",
+                path: ["recurringEventId"],
+                input: value,
+            });
+        }
+    });

--- a/packages/server/src/services/googleOAuthService.ts
+++ b/packages/server/src/services/googleOAuthService.ts
@@ -48,6 +48,12 @@ interface GoogleCalendarEvent {
     htmlLink?: string;
     created?: string;
     updated?: string;
+    recurringEventId?: string;
+    originalStartTime?: {
+        dateTime?: string;
+        date?: string;
+        timeZone?: string;
+    };
 }
 
 class GoogleOAuthService {
@@ -91,6 +97,14 @@ class GoogleOAuthService {
             htmlLink: event.htmlLink,
             created: event.created,
             updated: event.updated,
+            recurringEventId: event.recurringEventId,
+            originalStartTime: event.originalStartTime
+                ? {
+                    dateTime: event.originalStartTime.dateTime,
+                    date: event.originalStartTime.date,
+                    timeZone: event.originalStartTime.timeZone,
+                }
+                : undefined,
         };
     }
 
@@ -385,6 +399,32 @@ class GoogleOAuthService {
             });
         } catch (error) {
             console.error("Error deleting calendar event:", error);
+            throw error;
+        }
+    }
+
+    async cancelCalendarEventInstance(userId: string, calendarId: string, eventId: string): Promise<void> {
+        try {
+            const tokens = await this.refreshTokenIfNeeded(userId);
+            if (!tokens) {
+                throw new Error("No valid Google tokens found");
+            }
+
+            this.oauth2Client.setCredentials({
+                access_token: tokens.access_token,
+                refresh_token: tokens.refresh_token,
+            });
+
+            const calendar = google.calendar({ version: "v3", auth: this.oauth2Client });
+            await calendar.events.patch({
+                calendarId,
+                eventId,
+                requestBody: {
+                    status: "cancelled",
+                } as any,
+            });
+        } catch (error) {
+            console.error("Error cancelling recurring calendar event instance:", error);
             throw error;
         }
     }

--- a/packages/server/test/loaders/events.loader.test.ts
+++ b/packages/server/test/loaders/events.loader.test.ts
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 Cristian Barlutiu — Licensed under AGPL v3. See LICENSE.
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import googleOAuthService from "../../src/services/googleOAuthService";
+import { EventsLoader } from "../../src/loaders/events";
+import { requestContext } from "../../src/services/requestContext";
+
+const makeContext = () =>
+    ({
+        user: { id: "user-1", tenant: "tenant-1", admin: false },
+        role: { id: "role-1", title: "User", access: {} },
+        instanceId: "instance-1",
+        requestId: "req-1",
+        timestamp: Date.now(),
+    }) as any;
+
+describe("EventsLoader.remove", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test("deletes only the selected Google recurring instance when scope is single", async () => {
+        const cancelSpy = vi.spyOn(googleOAuthService, "cancelCalendarEventInstance").mockResolvedValue();
+        const deleteSpy = vi.spyOn(googleOAuthService, "deleteCalendarEvent").mockResolvedValue();
+
+        const result = await requestContext.run(makeContext(), async () => {
+            return EventsLoader.remove("google_calendar_id_series_20260701T090000Z", {
+                scope: "single",
+                calendarId: "calendar_id",
+                googleEventId: "series_20260701T090000Z",
+                recurringEventId: "series",
+            });
+        });
+
+        expect(result).toBe(true);
+        expect(cancelSpy).toHaveBeenCalledWith("user-1", "calendar_id", "series_20260701T090000Z");
+        expect(deleteSpy).not.toHaveBeenCalled();
+    });
+
+    test("deletes the parent Google recurring series when scope is series", async () => {
+        const deleteSpy = vi.spyOn(googleOAuthService, "deleteCalendarEvent").mockResolvedValue();
+
+        const result = await requestContext.run(makeContext(), async () => {
+            return EventsLoader.remove("google_calendar_id_series_20260701T090000Z", {
+                scope: "series",
+                calendarId: "calendar_id",
+                googleEventId: "series_20260701T090000Z",
+                recurringEventId: "series",
+            });
+        });
+
+        expect(result).toBe(true);
+        expect(deleteSpy).toHaveBeenCalledWith("user-1", "calendar_id", "series");
+    });
+});

--- a/packages/types/src/models/calendar.ts
+++ b/packages/types/src/models/calendar.ts
@@ -23,6 +23,18 @@ export interface ITimeLogExtended extends ITimeLog {
     taskId: string;
 }
 
+export interface IGoogleCalendarEventMetadata {
+    calendarId: string;
+    eventId: string;
+    recurringEventId?: string;
+    originalStartTime?: {
+        dateTime?: string;
+        date?: string;
+        timeZone?: string;
+    };
+    isRecurringInstance: boolean;
+}
+
 export interface ICalendarEvent {
     id: string;
     title: string;
@@ -40,6 +52,7 @@ export interface ICalendarEvent {
     updated?: string;
     original?: {
         htmlLink?: string;
+        google?: IGoogleCalendarEventMetadata;
     };
 }
 


### PR DESCRIPTION
## Summary

add support for deleting both single instances and entire series of Google Calendar events

## Changes

- extend type definitions with IGoogleCalendarEventMetadata
- update event delete API and server routes to accept deletion scope parameters
- implement backend logic to cancel single recurring instances or delete full series
- add RecurringDeleteDialog component for user selection of delete scope
- update frontend calendar store actions to use the dialog for recurring Google events
- add unit tests for the new dialog and events loader remove functionality

## How To Test

1. connect Google Calendar
2. have a recurring event and delete it

## Checklist

-   [x] This PR targets `dev` (not `main`)
-   [x] I ran the relevant tests locally
-   [x] I added/updated tests where appropriate
-   [x] I updated documentation where appropriate
-   [x] I verified this change does not introduce a security/privacy concern
-   [x] I considered backwards compatibility and migrations (if applicable)
-   [x] I signed the CLA (required for first-time contributors)

## CLA (first-time contributors)

Post this comment on the PR:

I have read the Contributor License Agreement in `.github/CLA.md` and I hereby agree to its terms. My GitHub username is @synapse

## Related Issues

-   Closes #
-   References #

## Release / Deployment Notes

-
